### PR TITLE
rtc: fixed usage of rtcsync option

### DIFF
--- a/sys_timex.c
+++ b/sys_timex.c
@@ -179,8 +179,8 @@ set_sync_status(int synchronised, double est_error, double max_error)
   }
 
 #ifdef LINUX
-  /* On Linux clear the UNSYNC flag only if rtcsync is enabled */
-  if (!CNF_GetRtcSync())
+  /* On Linux set the UNSYNC flag only if rtcsync is enabled */
+  if (CNF_GetRtcSync())
     synchronised = 0;
 #endif
 


### PR DESCRIPTION
https://chrony.tuxfamily.org/faq.html#_real_time_clock_issues:
`There are two approaches how chronyd can work with it. One is to use the rtcsync directive, which tells chronyd to enable a kernel mode which sets the RTC from the system clock every 11 minutes. `

If rtcsync is enabled, UNSYNC flag should be set and not cleared.